### PR TITLE
お気にり別アイテム表示実装

### DIFF
--- a/app/controllers/favourites_controller.rb
+++ b/app/controllers/favourites_controller.rb
@@ -16,6 +16,9 @@ class FavouritesController < ApplicationController
     )
     @favourite.destroy
   end
+
+  private
+  
   def fav_item
     @item = Item.find(params[:item_id])
   end

--- a/app/controllers/favourites_controller.rb
+++ b/app/controllers/favourites_controller.rb
@@ -1,9 +1,5 @@
 class FavouritesController < ApplicationController
-  before_action :fav_item, only: [:index, :create, :destroy]
-
-  def index
-    @favourite = Favourite.where(user_id: current_user.id)
-  end
+  before_action :fav_item, only: [:create, :destroy]
 
   def create
     @favourite = Favourite.new(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,12 +2,23 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :return_to_root_path, except: :top, unless: :user_signed_in?
   before_action :fav_new, only: [:index, :show]
+  before_action :items_all, only: [:index, :unfavourites]
+  before_action :fav_items, only: [:favourites, :unfavourites]
 
   def index
-    @items = current_user.items.with_attached_image.includes([:image_attachment])
     if params[:tag_name]
       @items = @items.tagged_with(params[:tag_name])
+      @tag = params[:tag_name]
     end
+  end
+
+  def favourites
+    render template: "items/index"
+  end
+
+  def unfavourites
+    @items = @items - @fav
+    render template: "items/index"
   end
 
   def show
@@ -76,5 +87,13 @@ class ItemsController < ApplicationController
 
   def fav_new
     @fav = Favourite.new
+  end
+
+  def items_all
+    @items = current_user.items.with_attached_image.includes([:image_attachment])
+  end
+
+  def fav_items
+    @fav = current_user.items.with_attached_image.includes([:image_attachment]).joins(:favourites).where(favourites: {user_id: current_user})
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,15 +12,6 @@ class ItemsController < ApplicationController
     end
   end
 
-  def favourites
-    render template: "items/index"
-  end
-
-  def unfavourites
-    @items = @items - @fav
-    render template: "items/index"
-  end
-
   def show
   end
 
@@ -75,6 +66,24 @@ class ItemsController < ApplicationController
     end
   end
 
+  def favourites
+    if @fav.present?
+      render template: "items/index"
+    else
+      redirect_to items_path, alert: "お気に入りがありません。お気に入りを見つけよう！"
+    end
+  end
+
+  def unfavourites
+    @unfav = @items - @fav
+    if @unfav.present?
+      render template: "items/index"
+    else
+      render :index, notice: "いじけ服はありません！みんな大活躍！！"
+    end
+  end
+
+
   private
 
   def return_to_root_path
@@ -94,6 +103,6 @@ class ItemsController < ApplicationController
   end
 
   def fav_items
-    @fav = current_user.items.with_attached_image.includes([:image_attachment]).joins(:favourites).where(favourites: {user_id: current_user})
+    @fav = current_user.items.joins(:favourites)
   end
 end

--- a/app/javascript/stylesheets/items.scss
+++ b/app/javascript/stylesheets/items.scss
@@ -72,6 +72,7 @@
       justify-content: space-evenly;
       flex-wrap: wrap;
       .card {
+        text-decoration: none;
         width: 30%;
         height: 300px;
         min-width:300px;
@@ -80,6 +81,9 @@
         border-color: #e7e7e7;
         margin-bottom: 20px;
         cursor: pointer;
+        a {
+          text-decoration: none;
+        }
         &:hover {
           box-shadow: 0 4px 5px 0 rgba(0,0,0,.14), 0 1px 10px 0 rgba(0,0,0,.12), 0 2px 4px -1px rgba(0,0,0,.2);
         }

--- a/app/javascript/stylesheets/items.scss
+++ b/app/javascript/stylesheets/items.scss
@@ -17,7 +17,7 @@
       flex-wrap: wrap;
       &__tag {
         @include btn(100%);
-        margin-right: 5px;
+        margin: 5px;
       }
     }
   }

--- a/app/javascript/stylesheets/items.scss
+++ b/app/javascript/stylesheets/items.scss
@@ -23,40 +23,42 @@
   }
 
   // item-indexページ
-  .items-counts {
-    display: block;
-    background-color: $primary-blue;
-    width: 50%;
-    margin: 20px auto;
-    font-size: 80px;
-    padding: 10px;
-    border-radius: 10px;
-    color: $main-white;
-  }
-  .item-index {
-    width: 75%;
-    margin: 0 auto;
-    flex-wrap: wrap;
-    display: flex;
-    justify-content: flex-start;
-    .item {
-      position: relative;
-      width: 200px;
-      height: 200px;
-      margin: 7px;
-      .link-btn {
-        @include btn(20px);
-        line-height: 20px;
-        border-radius: 0;
-        border: 0;
-        font-size: 20px;
-        position: absolute;
-        left: 0;
-        bottom: 0;
+  .items {
+    .items-counts {
+      display: block;
+      background-color: $primary-blue;
+      width: 50%;
+      margin: 20px auto;
+      font-size: 80px;
+      padding: 10px;
+      border-radius: 10px;
+      color: $main-white;
+    }
+    .item-index {
+      width: 75%;
+      margin: 0 auto;
+      flex-wrap: wrap;
+      display: flex;
+      justify-content: flex-start;
+      .item {
+        position: relative;
+        width: 200px;
+        height: 200px;
+        margin: 7px;
+        .link-btn {
+          @include btn(20px);
+          line-height: 20px;
+          border-radius: 0;
+          border: 0;
+          font-size: 20px;
+          position: absolute;
+          left: 0;
+          bottom: 0;
+        }
       }
     }
   }
-
+  
   // items-topページ
   .top {
     width: 90%;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -13,8 +13,7 @@
         .field
           = f.label :password
           - if @minimum_password_length
-            %em
-              (#{@minimum_password_length} 文字以上で入力して下さい)
+            %p (#{@minimum_password_length} 文字以上で入力して下さい)
           = f.password_field :password, placeholder: "8文字以上", autocomplete: "new-password"
         .field
           = f.label :password_confirmation

--- a/app/views/favourites/_favourite.html.haml
+++ b/app/views/favourites/_favourite.html.haml
@@ -1,5 +1,5 @@
 - if Favourite.find_by(user_id: current_user.id, item_id: item.id)
-  = link_to(item_favourite_path(@item, item.id), method: :delete, remote: true) do
+  = link_to(item_favourites_path(@item, item.id), method: :delete, remote: true) do
     .fav-btns__fav
       = image_tag "red-heart.png", size: "50x50", class: "heart-icon"
 

--- a/app/views/items/_items.html.haml
+++ b/app/views/items/_items.html.haml
@@ -3,5 +3,6 @@
 .item-index
   - items.each do |item|
     .item
-      = link_to 'Show', item, class: "link-btn"
-      = image_tag item.image.variant(combine_options:{resize: "200x200", crop: "200x200", gravity: :center}).processed
+      = link_to item do
+        .link-btn Show
+        = image_tag item.image.variant(combine_options:{resize: "200x200", crop: "200x200", gravity: :center}).processed

--- a/app/views/items/_items.html.haml
+++ b/app/views/items/_items.html.haml
@@ -1,0 +1,7 @@
+%h2.items-counts
+  Total #{items.count}
+.item-index
+  - items.each do |item|
+    .item
+      = link_to 'Show', item, class: "link-btn"
+      = image_tag item.image.variant(combine_options:{resize: "200x200", crop: "200x200", gravity: :center}).processed

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -2,7 +2,11 @@
   .items
     - if @tag.present?
       %h2 #{@tag}一覧
-    - else
+    - elsif @unfav.present?
+      %h2 いじけ服一覧
+    - elsif @items.present?
       %h2 アイテム一覧
+    - else
+      %h2 お気に入り一覧
     
-    = render 'items', items: @items || @fav
+    = render 'items', items: @unfav || @items || @fav

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,9 +1,8 @@
 .wrapper
-  %h2 アイテム一覧
-  %h2.items-counts
-    Total #{@items.count}
-  .item-index
-    - @items.each do |item|
-      .item
-        = link_to 'Show', item, class: "link-btn"
-        = image_tag item.image.variant(combine_options:{resize: "200x200", crop: "200x200", gravity: :center}).processed
+  .items
+    - if @tag.present?
+      %h2 #{@tag}一覧
+    - else
+      %h2 アイテム一覧
+    
+    = render 'items', items: @items || @fav

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,8 +8,7 @@
 
     %div.tags
       - @item.tags.each do |tag|
-        .tags__tag
-          = tag.name
+        = link_to tag.name, items_path(tag_name: tag.name), class: "tags__tag"
       
     %div
       = @item.season

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -7,25 +7,28 @@
         %span のクローゼット
       .cards
         .card.card--rest
-          %h2.card__title.card__title--rest
-            いじけ服
-          .card__number.card__number--rest
-            #{@items.count - @favourites.count}
-          %p.card__info
-            初めまして、お久しぶりです？ お気に入りに入れず寂しそうな服たち
+          = link_to "#" do
+            %h2.card__title.card__title--rest
+              いじけ服
+            .card__number.card__number--rest
+              #{@items.count - @favourites.count}
+            %p.card__info
+              初めまして、お久しぶりです？ お気に入りに入れず寂しそうな服たち
         .card.card--all
-          %h2.card__title.card__title--all
-            コレクション
-          .card__number.card__number--all
-            #{@items.count}
-          %p.card__info
-            たくさんの服たちがあなたを待っています! 大好きな服やお久しぶりの服、服と向き合ってみませんか？
+          = link_to items_path do
+            %h2.card__title.card__title--all
+              コレクション
+            .card__number.card__number--all
+              #{@items.count}
+            %p.card__info
+              たくさんの服たちがあなたを待っています! 大好きな服やお久しぶりの服、服と向き合ってみませんか？
         .card.card--fav
-          %h2.card__title.card__title--fav
-            お気に入り
-          .card__number.card__number--fav
-            #{@favourites.count}
-          %p.card__info
-            いつもお世話になっています。大好きな服をもっと増やして行きたいですね！きっとまだまだ、素敵な出会いがあるはず。
+          = link_to "#" do
+            %h2.card__title.card__title--fav
+              お気に入り
+            .card__number.card__number--fav
+              #{@favourites.count}
+            %p.card__info
+              いつもお世話になっています。大好きな服をもっと増やして行きたいですね！きっとまだまだ、素敵な出会いがあるはず。
     - else
       %h1 あなたのクローゼットを覗いてみませんか？

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -4,7 +4,7 @@
       %h1.title
         %span.nickname
           #{current_user.nickname} 
-        %span のクローゼット
+        %span さんのクローゼット
       .cards
         .card.card--rest
           = link_to unfavourites_items_path do

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -7,7 +7,7 @@
         %span のクローゼット
       .cards
         .card.card--rest
-          = link_to "#" do
+          = link_to unfavourites_items_path do
             %h2.card__title.card__title--rest
               いじけ服
             .card__number.card__number--rest
@@ -23,7 +23,7 @@
             %p.card__info
               たくさんの服たちがあなたを待っています! 大好きな服やお久しぶりの服、服と向き合ってみませんか？
         .card.card--fav
-          = link_to "#" do
+          = link_to favourites_items_path do
             %h2.card__title.card__title--fav
               お気に入り
             .card__number.card__number--fav

--- a/app/views/items/top.html.haml
+++ b/app/views/items/top.html.haml
@@ -11,7 +11,7 @@
             %h2.card__title.card__title--rest
               いじけ服
             .card__number.card__number--rest
-              #{@items.count - @favourites.count}
+              #{@unfav.count}
             %p.card__info
               初めまして、お久しぶりです？ お気に入りに入れず寂しそうな服たち
         .card.card--all
@@ -27,7 +27,7 @@
             %h2.card__title.card__title--fav
               お気に入り
             .card__number.card__number--fav
-              #{@favourites.count}
+              #{@fav.count}
             %p.card__info
               いつもお世話になっています。大好きな服をもっと増やして行きたいですね！きっとまだまだ、素敵な出会いがあるはず。
     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
   root 'items#top'
 
   resources :items do
-    resources :favourites, only: [:index, :create, :destroy]
+    resource :favourites, only: [:create, :destroy]
+    collection do
+      get "favourites"
+      get "unfavourites"
+    end
   end
   resources :tags, only: :index do
     collection do


### PR DESCRIPTION
# What
- トップページカードに遷移先指定
 - コレクション→items all
- タグ毎のアイテム一覧表示
- タグ一覧ページ作成
- お気に入り状況により、フラッシュメッセージの表示変更

# Why
- topページのカードより、アイテムの確認ページへ遷移できる
- ユーザーはより管理しやすくなる
- お気に入り状況により、メッセージを表示し、ユーザーにアイテム管理を促す事ができる→アプリの目標とするアイテム管理へと導く